### PR TITLE
[RunWhen] - GitOps Manifest Updates from RunSession 655

### DIFF
--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -512,7 +512,7 @@ spec:
           readinessProbe:
             initialDelaySeconds: 15
             exec:
-              command: ["/bin/grpc_health_probe", "-addr=:7071", "-rpc-timeout=5s"]
+              command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
           livenessProbe:
             initialDelaySeconds: 15
             periodSeconds: 10


### PR DESCRIPTION
A RunSession (started by shea.stewart@runwhen.com) with the following tasks has produced this Pull Request: 
- Check Readiness and Liveness Probe Configuration for Deployments in Namespace `${NAMESPACE}`

To view the RunSession, click [this link](https://app.test.runwhen.com/map/t-shea-t-01#selectedRunSessions=655)

This patch was influenced from the following task output:
```
{"object_type":"deployment","object_name":"cartservice","probe_type":"readinessProbe","exec":"true","invalid_command":"/bin/grpc_health_probe -addr=:7071 -rpc-timeout=5s","valid_command":"/bin/grpc_health_probe -addr=:7070 -rpc-timeout=5s","container":"server"}
```

[RunWhen Workspace](https://app.test.runwhen.com/map/t-shea-t-01)