### PR TITLE
[RunWhen] - GitOps Manifest Updates for Deployment-checkoutservice

### DIFF
--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -231,7 +231,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
-  labels: 
+  labels:
     app: frontend
 spec:
   replicas: 3
@@ -538,7 +538,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loadgenerator
-  labels: 
+  labels:
     app: loadgenerator
 spec:
   selector:


### PR DESCRIPTION
### RunSession Details

A RunSession (started by none) with the following tasks has produced this Pull Request: 

- Remediate Readiness and Liveness Probe GitOps Manifests in Namespace `${NAMESPACE}`

To view the RunSession, click [this link](https://app.beta.runwhen.com/map/b-online-boutique?selectedRunSessions=1671)

### Change Details
[Change] Container `server` in Deployment `checkoutservice` had an invalid exec command for livenessProbe. The updated command is `/bin/grpc_health_probe -addr=:5050`<br>

The following details prompted this change: 
```
{
  "remediation_type": "probe_update",
  "object_type": "Deployment",
  "object_name": "checkoutservice",
  "probe_type": "livenessProbe",
  "exec": "true",
  "invalid_command": "/bin/grpc_health_probe -addr=:5050",
  "valid_command": "/bin/grpc_health_probe -addr=:5050",
  "container": "server"
}
```

---
[RunWhen Workspace](https://app.beta.runwhen.com/map/b-online-boutique)