### PR TITLE
[RunWhen] - GitOps Manifest Updates for Deployment-cartservice

### DIFF
--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -231,7 +231,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
-  labels: 
+  labels:
     app: frontend
 spec:
   replicas: 3
@@ -514,7 +514,7 @@ spec:
           readinessProbe:
             initialDelaySeconds: 15
             exec:
-              command: ["/bin/grpc_health_probe", "-addr=:7071", "-rpc-timeout=5s"]
+              command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
           livenessProbe:
             initialDelaySeconds: 15
             periodSeconds: 10
@@ -538,7 +538,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loadgenerator
-  labels: 
+  labels:
     app: loadgenerator
 spec:
   selector:


### PR DESCRIPTION
### RunSession Details

A RunSession (started by none) with the following tasks has produced this Pull Request: 

- Expand Persistent Volume Claims in Namespace `${NAMESPACE}`, Increase ResourceQuota Limit for Namespace `${NAMESPACE}` in GitHub GitOps Repository, Remediate Readiness and Liveness Probe GitOps Manifests in Namespace `${NAMESPACE}`, Adjust Pod Resources to Match VPA Recommendation in `${NAMESPACE}`

To view the RunSession, click [this link](https://app.beta.runwhen.com/map/b-online-boutique?selectedRunSessions=27296)

### Change Details
[Change] Container `server` in Deployment `cartservice` had an invalid exec command for readinessProbe. The updated command is `/bin/grpc_health_probe -addr=:7070 -rpc-timeout=5s`<br>

The following details prompted this change: 
```
{
  "remediation_type": "probe_update",
  "object_type": "Deployment",
  "object_name": "cartservice",
  "probe_type": "readinessProbe",
  "exec": "true",
  "invalid_command": "/bin/grpc_health_probe -addr=:7071 -rpc-timeout=5s",
  "valid_command": "/bin/grpc_health_probe -addr=:7070 -rpc-timeout=5s",
  "container": "server"
}
```

---
[RunWhen Workspace](https://app.beta.runwhen.com/map/b-online-boutique)